### PR TITLE
Accept typeface face lists on the theme, and drop dark mode typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Go SDK is a wrapper for Authsignal's Management API and is used by Authsign
 ## Installation
 
 ```
-go get github.com/authsignal/authsignal-management-go/v4
+go get github.com/authsignal/authsignal-management-go/v5
 ```
 
 ## Example Usage
@@ -16,7 +16,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/authsignal/authsignal-management-go/v4"
+	"github.com/authsignal/authsignal-management-go/v5"
 )
 
 const authsignalSecret = "<management api secret retrieved from the admin portal>"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/authsignal/authsignal-management-go/v4
+module github.com/authsignal/authsignal-management-go/v5
 
 go 1.22.0

--- a/theme.go
+++ b/theme.go
@@ -55,12 +55,49 @@ type PageBackground struct {
 	BackgroundImageUrl NullableJsonInput[string] `json:"backgroundImageUrl,omitempty"`
 }
 
-type Display struct {
+// MaxFontFacesPerTypeface mirrors the cap the Management API enforces on each typeface's face list.
+const MaxFontFacesPerTypeface = 6
+
+// FontWeight is a single weight ("400") or an ascending range ("100 900"). The API stores a single
+// weight as a number and a range as a string, so it can come back as either JSON type.
+type FontWeight string
+
+func (w FontWeight) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(w))
+}
+
+func (w *FontWeight) UnmarshalJSON(data []byte) error {
+	var asString string
+	if err := json.Unmarshal(data, &asString); err == nil {
+		*w = FontWeight(asString)
+		return nil
+	}
+
+	var asNumber json.Number
+	if err := json.Unmarshal(data, &asNumber); err != nil {
+		return fmt.Errorf("font weight must be a string or a number, got %s", data)
+	}
+
+	*w = FontWeight(asNumber.String())
+
+	return nil
+}
+
+type FontFace struct {
+	Url    string     `json:"url"`
+	Weight FontWeight `json:"weight,omitempty"`
+}
+
+type Typeface struct {
+	Faces NullableJsonInput[[]FontFace] `json:"faces,omitempty"`
+	// Deprecated: the single-url shape. Prefer Faces, which carries a weight per file.
 	FontUrl NullableJsonInput[string] `json:"fontUrl,omitempty"`
 }
 
+// Typography sits on Theme only. A typeface is shared by both colour modes, so DarkMode has none.
 type Typography struct {
-	Display NullableJsonInput[Display] `json:"display,omitempty"`
+	Text    NullableJsonInput[Typeface] `json:"text,omitempty"`
+	Display NullableJsonInput[Typeface] `json:"display,omitempty"`
 }
 
 type DarkMode struct {
@@ -68,7 +105,6 @@ type DarkMode struct {
 	Colors         NullableJsonInput[Colors]         `json:"colors,omitempty"`
 	Container      NullableJsonInput[Container]      `json:"container,omitempty"`
 	PageBackground NullableJsonInput[PageBackground] `json:"pageBackground,omitempty"`
-	Typography     NullableJsonInput[Typography]     `json:"typography,omitempty"`
 	LogoUrl        NullableJsonInput[string]         `json:"logoUrl,omitempty"`
 	WatermarkUrl   NullableJsonInput[string]         `json:"watermarkUrl,omitempty"`
 	FaviconUrl     NullableJsonInput[string]         `json:"faviconUrl,omitempty"`
@@ -137,12 +173,19 @@ type PageBackgroundResponse struct {
 	BackgroundImageUrl string `json:"backgroundImageUrl"`
 }
 
-type DisplayResponse struct {
-	FontUrl string `json:"fontUrl"`
+type FontFaceResponse struct {
+	Url    string     `json:"url"`
+	Weight FontWeight `json:"weight"`
+}
+
+type TypefaceResponse struct {
+	Faces   []FontFaceResponse `json:"faces"`
+	FontUrl string             `json:"fontUrl"`
 }
 
 type TypographyResponse struct {
-	Display DisplayResponse `json:"display"`
+	Text    TypefaceResponse `json:"text"`
+	Display TypefaceResponse `json:"display"`
 }
 
 type DarkModeResponse struct {
@@ -150,7 +193,6 @@ type DarkModeResponse struct {
 	Colors         ColorsResponse         `json:"colors"`
 	Container      ContainerResponse      `json:"container"`
 	PageBackground PageBackgroundResponse `json:"pageBackground"`
-	Typography     TypographyResponse     `json:"typography"`
 	LogoUrl        string                 `json:"logoUrl"`
 	WatermarkUrl   string                 `json:"watermarkUrl"`
 	FaviconUrl     string                 `json:"faviconUrl"`

--- a/theme_test.go
+++ b/theme_test.go
@@ -1,0 +1,111 @@
+package authsignal
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFontWeightMarshalsAsAString(t *testing.T) {
+	face := FontFace{Url: "https://cdn.example.com/regular.woff2", Weight: "400"}
+
+	jsonBody, err := json.Marshal(face)
+	if err != nil {
+		t.Fatalf("failed to marshal json")
+	}
+
+	expectedJson := "{\"url\":\"https://cdn.example.com/regular.woff2\",\"weight\":\"400\"}"
+
+	if string(jsonBody) != expectedJson {
+		t.Fatalf("bad json. expected: %v. got : %v", expectedJson, string(jsonBody))
+	}
+}
+
+func TestFontWeightIsOmittedWhenUnset(t *testing.T) {
+	face := FontFace{Url: "https://cdn.example.com/regular.woff2"}
+
+	jsonBody, err := json.Marshal(face)
+	if err != nil {
+		t.Fatalf("failed to marshal json")
+	}
+
+	expectedJson := "{\"url\":\"https://cdn.example.com/regular.woff2\"}"
+
+	if string(jsonBody) != expectedJson {
+		t.Fatalf("bad json. expected: %v. got : %v", expectedJson, string(jsonBody))
+	}
+}
+
+// The API coerces a single weight to a number and leaves a range as a string, so a read has to take both.
+func TestFontWeightUnmarshalsFromANumberOrAString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		body     string
+		expected FontWeight
+	}{
+		{name: "number", body: "{\"url\":\"https://cdn.example.com/a.woff2\",\"weight\":400}", expected: "400"},
+		{name: "range", body: "{\"url\":\"https://cdn.example.com/a.woff2\",\"weight\":\"100 900\"}", expected: "100 900"},
+		{name: "absent", body: "{\"url\":\"https://cdn.example.com/a.woff2\"}", expected: ""},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var face FontFaceResponse
+
+			if err := json.Unmarshal([]byte(testCase.body), &face); err != nil {
+				t.Fatalf("failed to unmarshal json: %v", err)
+			}
+
+			if face.Weight != testCase.expected {
+				t.Fatalf("bad weight. expected: %v. got : %v", testCase.expected, face.Weight)
+			}
+		})
+	}
+}
+
+func TestFontWeightRejectsAValueThatIsNeitherStringNorNumber(t *testing.T) {
+	var face FontFaceResponse
+
+	if err := json.Unmarshal([]byte("{\"url\":\"https://cdn.example.com/a.woff2\",\"weight\":true}"), &face); err == nil {
+		t.Fatalf("expected an error for a boolean weight")
+	}
+}
+
+func TestThemeTypographyMarshalsBothRoles(t *testing.T) {
+	theme := Theme{
+		Typography: SetValue(Typography{
+			Text: SetValue(Typeface{
+				Faces: SetValue([]FontFace{
+					{Url: "https://cdn.example.com/regular.woff2", Weight: "400"},
+					{Url: "https://cdn.example.com/variable.woff2", Weight: "100 900"},
+				}),
+			}),
+			Display: SetValue(Typeface{FontUrl: SetValue("https://cdn.example.com/display.woff2")}),
+		}),
+	}
+
+	jsonBody, err := json.Marshal(theme)
+	if err != nil {
+		t.Fatalf("failed to marshal json")
+	}
+
+	expectedJson := "{\"typography\":{\"text\":{\"faces\":[{\"url\":\"https://cdn.example.com/regular.woff2\",\"weight\":\"400\"},{\"url\":\"https://cdn.example.com/variable.woff2\",\"weight\":\"100 900\"}]},\"display\":{\"fontUrl\":\"https://cdn.example.com/display.woff2\"}}}"
+
+	if string(jsonBody) != expectedJson {
+		t.Fatalf("bad json. expected: %v. got : %v", expectedJson, string(jsonBody))
+	}
+}
+
+func TestFacesCanBeClearedWithNull(t *testing.T) {
+	typeface := Typeface{Faces: SetNull([]FontFace{})}
+
+	jsonBody, err := json.Marshal(typeface)
+	if err != nil {
+		t.Fatalf("failed to marshal json")
+	}
+
+	expectedJson := "{\"faces\":null}"
+
+	if string(jsonBody) != expectedJson {
+		t.Fatalf("bad json. expected: %v. got : %v", expectedJson, string(jsonBody))
+	}
+}


### PR DESCRIPTION
## Problem

The Management API changed how a theme carries fonts. A typeface is now a list of font files, each with the weight it covers, and it applies to both colour modes rather than one per mode. The API no longer accepts `darkMode.typography` and rejects any request that sends it.

The SDK still modelled the old shape, so `DarkMode.Typography` produced a `400` at runtime with nothing to catch it at compile time.

## Approach

`Display` becomes `Typeface` and gains a `Faces` list beside the existing `FontUrl`. `Typography` gains a `Text` role for body copy alongside `Display` for headings, and moves off `DarkMode` and `DarkModeResponse` altogether.

`FontWeight` is a new type that reads either JSON type. The API stores a single weight as a number and a range such as `100 900` as a string, so a response can carry either; it always writes as a string, which the API coerces.

`FontUrl` is kept and marked deprecated, so no existing caller has to migrate.

## Breaking change

This is `v5`. Removing `DarkMode.Typography` and renaming `Display` are both source-breaking, and Go requires a new module path for either.

```
go get github.com/authsignal/authsignal-management-go/v5
```

Callers setting a dark mode font should set it at the top level instead. There is no longer a way to vary a typeface by colour mode.