### PR TITLE
Accept the link underline and shadow switches on the theme

### DIFF
--- a/theme.go
+++ b/theme.go
@@ -100,6 +100,15 @@ type Typography struct {
 	Display NullableJsonInput[Typeface] `json:"display,omitempty"`
 }
 
+// Links and Shadows sit on Theme only. Neither is a design token, so DarkMode has neither.
+type Links struct {
+	Underline NullableJsonInput[bool] `json:"underline,omitempty"`
+}
+
+type Shadows struct {
+	Enabled NullableJsonInput[bool] `json:"enabled,omitempty"`
+}
+
 type DarkMode struct {
 	Borders        NullableJsonInput[Borders]        `json:"borders,omitempty"`
 	Colors         NullableJsonInput[Colors]         `json:"colors,omitempty"`
@@ -117,6 +126,8 @@ type Theme struct {
 	Container      NullableJsonInput[Container]      `json:"container,omitempty"`
 	PageBackground NullableJsonInput[PageBackground] `json:"pageBackground,omitempty"`
 	Typography     NullableJsonInput[Typography]     `json:"typography,omitempty"`
+	Links          NullableJsonInput[Links]          `json:"links,omitempty"`
+	Shadows        NullableJsonInput[Shadows]        `json:"shadows,omitempty"`
 	LogoUrl        NullableJsonInput[string]         `json:"logoUrl,omitempty"`
 	WatermarkUrl   NullableJsonInput[string]         `json:"watermarkUrl,omitempty"`
 	FaviconUrl     NullableJsonInput[string]         `json:"faviconUrl,omitempty"`
@@ -188,6 +199,15 @@ type TypographyResponse struct {
 	Display TypefaceResponse `json:"display"`
 }
 
+// A pointer, because the API omits a switch the tenant never set and `false` is a value they set.
+type LinksResponse struct {
+	Underline *bool `json:"underline"`
+}
+
+type ShadowsResponse struct {
+	Enabled *bool `json:"enabled"`
+}
+
 type DarkModeResponse struct {
 	Borders        BordersResponse        `json:"borders"`
 	Colors         ColorsResponse         `json:"colors"`
@@ -205,6 +225,8 @@ type ThemeResponse struct {
 	Container      ContainerResponse      `json:"container"`
 	PageBackground PageBackgroundResponse `json:"pageBackground"`
 	Typography     TypographyResponse     `json:"typography"`
+	Links          LinksResponse          `json:"links"`
+	Shadows        ShadowsResponse        `json:"shadows"`
 	LogoUrl        string                 `json:"logoUrl"`
 	WatermarkUrl   string                 `json:"watermarkUrl"`
 	FaviconUrl     string                 `json:"faviconUrl"`

--- a/theme_test.go
+++ b/theme_test.go
@@ -95,6 +95,92 @@ func TestThemeTypographyMarshalsBothRoles(t *testing.T) {
 	}
 }
 
+func TestSwitchesMarshalWhenSetToFalse(t *testing.T) {
+	theme := Theme{
+		Links:   SetValue(Links{Underline: SetValue(false)}),
+		Shadows: SetValue(Shadows{Enabled: SetValue(false)}),
+	}
+
+	jsonBody, err := json.Marshal(theme)
+	if err != nil {
+		t.Fatalf("failed to marshal json")
+	}
+
+	expectedJson := "{\"links\":{\"underline\":false},\"shadows\":{\"enabled\":false}}"
+
+	if string(jsonBody) != expectedJson {
+		t.Fatalf("bad json. expected: %v. got : %v", expectedJson, string(jsonBody))
+	}
+}
+
+func TestSwitchesCanBeClearedWithNull(t *testing.T) {
+	theme := Theme{
+		Links:   SetValue(Links{Underline: SetNull(false)}),
+		Shadows: SetValue(Shadows{Enabled: SetNull(false)}),
+	}
+
+	jsonBody, err := json.Marshal(theme)
+	if err != nil {
+		t.Fatalf("failed to marshal json")
+	}
+
+	expectedJson := "{\"links\":{\"underline\":null},\"shadows\":{\"enabled\":null}}"
+
+	if string(jsonBody) != expectedJson {
+		t.Fatalf("bad json. expected: %v. got : %v", expectedJson, string(jsonBody))
+	}
+}
+
+// The API omits a switch the tenant never set, which has to read back as unset rather than as off.
+func TestSwitchesReadAbsentApartFromFalse(t *testing.T) {
+	testCases := []struct {
+		name     string
+		body     string
+		expected *bool
+	}{
+		{name: "absent", body: "{}", expected: nil},
+		{name: "empty switch", body: "{\"links\":{},\"shadows\":{}}", expected: nil},
+		{name: "off", body: "{\"links\":{\"underline\":false},\"shadows\":{\"enabled\":false}}", expected: boolPointer(false)},
+		{name: "on", body: "{\"links\":{\"underline\":true},\"shadows\":{\"enabled\":true}}", expected: boolPointer(true)},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var theme ThemeResponse
+
+			if err := json.Unmarshal([]byte(testCase.body), &theme); err != nil {
+				t.Fatalf("failed to unmarshal json: %v", err)
+			}
+
+			assertBoolPointer(t, "underline", theme.Links.Underline, testCase.expected)
+			assertBoolPointer(t, "shadows enabled", theme.Shadows.Enabled, testCase.expected)
+		})
+	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func assertBoolPointer(t *testing.T, name string, actual *bool, expected *bool) {
+	t.Helper()
+
+	if expected == nil {
+		if actual != nil {
+			t.Fatalf("bad %v. expected: unset. got : %v", name, *actual)
+		}
+		return
+	}
+
+	if actual == nil {
+		t.Fatalf("bad %v. expected: %v. got : unset", name, *expected)
+	}
+
+	if *actual != *expected {
+		t.Fatalf("bad %v. expected: %v. got : %v", name, *expected, *actual)
+	}
+}
+
 func TestFacesCanBeClearedWithNull(t *testing.T) {
 	typeface := Typeface{Faces: SetNull([]FontFace{})}
 


### PR DESCRIPTION
The Management API now takes `links.underline` and `shadows.enabled` on the tenant theme, read by the pre-built UI. Both are optional, and absent means the current behaviour.

Neither is a design token, so neither sits on `DarkMode` — the API refuses a per-mode value for either.

The response types hold `*bool` rather than `bool`. The API omits a switch the tenant never set, and `false` is the value that turns one off, so a plain `bool` would read "never set" and "off" as the same thing.

Additive only, so this is v5.1.0 and the module path is unchanged. Needs tagging before the Terraform provider can resolve it.